### PR TITLE
WFLY-9743 WildScribe: use strike-through for deprecated model attribu…

### DIFF
--- a/site-generator/src/main/java/org/jboss/wildscribe/site/Child.java
+++ b/site-generator/src/main/java/org/jboss/wildscribe/site/Child.java
@@ -13,15 +13,17 @@ import java.util.List;
 public class Child implements Comparable<Child> {
     private final String name;
     private final String description;
+    private final Deprecated deprecated;
 
     /**
      * If this is a non-wildcard registration
      */
     private final List<Child> children;
 
-    public Child(String name, String description, List<Child> children) {
+    public Child(String name, String description, Deprecated deprecated, List<Child> children) {
         this.name = name;
         this.description = description;
+        this.deprecated = deprecated;
         this.children = children;
     }
 
@@ -31,6 +33,10 @@ public class Child implements Comparable<Child> {
 
     public String getDescription() {
         return description;
+    }
+
+    public Deprecated getDeprecated() {
+        return deprecated;
     }
 
     public List<Child> getChildren() {
@@ -52,13 +58,13 @@ public class Child implements Comparable<Child> {
         if (modelDesc.isDefined()) {
             for (Property child : modelDesc.asPropertyList()) {
                 if (!child.getName().equals("*")) {
-                    registrations.add(new Child(child.getName(), child.getValue().get("description").asString(""), null));
+                    registrations.add(new Child(child.getName(), child.getValue().get("description").asString(""), Deprecated.fromModel(child.getValue()), null));
                 }
             }
         }
         Collections.sort(registrations);
 
-        Child op = new Child(name, description, registrations);
+        Child op = new Child(name, description, Deprecated.fromModel(property.getValue()), registrations);
 
         return op;
     }

--- a/site-generator/src/main/resources/staticresources/css/main.css
+++ b/site-generator/src/main/resources/staticresources/css/main.css
@@ -66,3 +66,6 @@ dl:after {content:"";display:table;clear:both;}
   border-top: 1px solid #eee;
 }
 
+a.deprecated {
+    text-decoration: line-through;
+}

--- a/site-generator/src/main/resources/templates/resource.html
+++ b/site-generator/src/main/resources/templates/resource.html
@@ -39,7 +39,7 @@
 
                     <#if child.children?size == 0>
                         <#noautoesc>
-                        <a href="${version.product?url}/${version.version?url}${currenturl}/${child.name}/index.html">${child.name}</a>
+                        <a href="${version.product?url}/${version.version?url}${currenturl}/${child.name}/index.html" class="${child.deprecated.deprecated?then('deprecated','')}">${child.name}</a>
                         </#noautoesc>
                         <#else>
                             <b>${child.name}</b>
@@ -51,10 +51,8 @@
                         <#list child.children as c>
                             <li>
                                 <#noautoesc>
-                                <a href="${version.product?url}/${version.version?url}${currenturl}/${child.name}/${c.name}/index.html">
+                                <a href="${version.product?url}/${version.version?url}${currenturl}/${child.name}/${c.name}/index.html" class="${c.deprecated.deprecated?then('deprecated','')}">${c.name}</a>
                                 </#noautoesc>
-                                        ${c.name}
-                                </a>
                                 ${c.description}
                             </li>
                         </#list>
@@ -110,9 +108,7 @@
                 <ul>
                     <#list model.attributes as attribute>
                         <li>
-                            <a href="#" data-toggle="collapse" data-target="#attribute-${attribute.name}">
-                                ${attribute.name}
-                            </a>
+                            <a href="#" data-toggle="collapse" data-target="#attribute-${attribute.name}" class="${attribute.deprecated.deprecated?then('deprecated','')}">${attribute.name}</a>
                             ${attribute.description}
                         </li>
 
@@ -270,9 +266,7 @@
             <ul>
                 <#list model.operations as op>
                     <li>
-                        <a href="#"  data-toggle="collapse" data-target="#operation-${op.name}">
-                            ${op.name}
-                        </a>
+                        <a href="#" data-toggle="collapse" data-target="#operation-${op.name}" class="${(op.deprecated.deprecated)?then('deprecated','')}">${op.name}</a>
                         ${op.description}
 
                         <div id="operation-${op.name}" class="collapse">


### PR DESCRIPTION
…te/operation/children names; fix whitespace in links

@stuartwdouglas As briefly discussed in Brno.

Jira
https://issues.jboss.org/browse/WFLY-9743 (work towards https://issues.jboss.org/browse/WFLY-9744)

regenerated website PR
https://github.com/wildscribe/wildscribe.github.io/pull/4