### PR TITLE
message dumper - exit after printing help when input parameters are not provided

### DIFF
--- a/message-dumper/src/main/java/org/wildscribe/logs/Main.java
+++ b/message-dumper/src/main/java/org/wildscribe/logs/Main.java
@@ -30,6 +30,7 @@ public class Main {
     public static void main(String[] params) throws Exception {
         if(params.length != 2) {
             System.out.println("Usage: dumper.jar path-to-modules output-file");
+            System.exit(1);
         }
         String path = params[0];
         List<LogMessage> messages = new ArrayList<>();


### PR DESCRIPTION
Display help and exit with return value 1, do not continue further (throws java.lang.ArrayIndexOutOfBoundsException: at org.wildscribe.logs.Main.main(Main.java:34))