### PR TITLE
Do not require a minimum of Maven equivalent to the version of maven-…

### DIFF
--- a/wildscribe-maven-plugin/pom.xml
+++ b/wildscribe-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
     <packaging>maven-plugin</packaging>
 
     <prerequisites>
-        <maven>${version.org.apache.maven.maven-core}</maven>
+        <maven>3.6.0</maven>
     </prerequisites>
 
     <properties>


### PR DESCRIPTION
…core being used. Older versions should work.